### PR TITLE
Extended the release pipeline with a manually triggered publication task

### DIFF
--- a/cf-plugin-backup-release.yaml
+++ b/cf-plugin-backup-release.yaml
@@ -114,3 +114,21 @@ jobs:
     - put: s3.cf-plugin-backup.release
       params:
         file: 'cf-plugin-backup/cf-plugin-backup-*release*.tgz'
+- name: publish
+  plan:
+  - aggregate:
+    # NOTE: None of the input have trigger
+    #       Because this *must* be a manual step
+    - get: src-release
+    - get: src-ci
+  - task: publish
+    file: src-ci/tasks/publish.yaml
+    params:
+      CONTACT: placeholder
+      NAME: SUSE LLC
+      HOMEURL: https://www.suse.com/
+      COMPANY: SUSE LLC
+      UPSTREAM: ((upstream))
+      GITHUB_USER: ((github-username))
+      GITHUB_TOKEN: ((github-access-token))
+      GITHUB_KEY: ((github-private-key))

--- a/cf-plugin-backup-release.yaml
+++ b/cf-plugin-backup-release.yaml
@@ -131,6 +131,7 @@ jobs:
         globs:
         - hub-linux-amd64-*
     - get: src-release
+      passed: [release]
     - get: src-ci
   - task: publish
     file: src-ci/tasks/publish.yaml

--- a/cf-plugin-backup-release.yaml
+++ b/cf-plugin-backup-release.yaml
@@ -26,6 +26,14 @@ resources:
     regexp: ((s3-prefix))cf-plugin-backup-(.*release.*)\.tgz
     secret_access_key: ((s3-secret-key))
 
+- name: hub-release
+  type: github-release
+  source:
+    owner: github
+    repository: hub
+    access_token: ((github-access-token))
+    pre_release: true
+
 - name: src-release
   type: github-release
   source:
@@ -119,6 +127,11 @@ jobs:
   - aggregate:
     # NOTE: None of the input have trigger
     #       Because this *must* be a manual step
+    - get: hub-release
+      params:
+        version: v2.3.0-pre10
+        globs:
+        - hub-linux-amd64-*
     - get: src-release
     - get: src-ci
   - task: publish

--- a/cf-plugin-backup-release.yaml
+++ b/cf-plugin-backup-release.yaml
@@ -103,10 +103,8 @@ jobs:
   - aggregate:
     - get: src
       passed: [build]
-      trigger: true
     - get: src-ci
       passed: [build]
-      trigger: true
   - task: tools
     file: src-ci/tasks/tools.yaml
   - task: release

--- a/cf-plugin-backup-release.yaml
+++ b/cf-plugin-backup-release.yaml
@@ -136,11 +136,11 @@ jobs:
   - task: publish
     file: src-ci/tasks/publish.yaml
     params:
-      CONTACT: placeholder
-      NAME: SUSE LLC
-      HOMEURL: https://www.suse.com/
-      COMPANY: SUSE LLC
-      UPSTREAM: ((upstream))
-      GITHUB_USER: ((github-username))
-      GITHUB_TOKEN: ((github-access-token))
+      COMPANY: SUSE Platform Engineering
+      CONTACT: suse-cap-maintainers@suse.de
       GITHUB_KEY: ((github-private-key))
+      GITHUB_TOKEN: ((github-access-token))
+      GITHUB_USER: ((github-username))
+      HOMEURL: https://www.suse.com/
+      NAME: SUSE Platform Engineering
+      UPSTREAM: ((upstream))

--- a/config-production.yaml
+++ b/config-production.yaml
@@ -1,6 +1,8 @@
 # Production configuration for the cf-plugin-backup pipelines
 # Note that the secrets are not here; they are in $CONCOURSE_SECRETS_FILE
 
+upstream: cloudfoundry/cli-plugin-repo
+
 src-owner:                   SUSE
 src-repo:                         cf-plugin-backup
 src-name:                    SUSE/cf-plugin-backup

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -8,8 +8,6 @@ TOP=$PWD
 # from.
 FORK=SUSE/cli-plugin-repo
 
-HUB_RELEASE=https://github.com/github/hub/releases/download/v2.3.0-pre10/hub-linux-amd64-2.3.0-pre10.tgz
-
 if [ -z "$UPSTREAM"  ]; then
   echo "Don't know where to make the pull request, UPSTREAM is undefined"
   exit 1
@@ -146,8 +144,7 @@ echo
 echo
 echo Creating the pull request ...
 
-# Get the "hub" cli -- https://hub.github.com/hub.1.html
-curl -L ${HUB_RELEASE} | tar xvz --wildcards --strip-components=2 '*/bin/hub'
+tar xvzf hub-release/hub-linux-amd64-* --wildcards --strip-components=2 '*/bin/hub'
 HUB="${PWD}/hub"
 chmod +x ${HUB}
 
@@ -169,7 +166,7 @@ cd src/code.cloudfoundry.org/cli-plugin-repo
 # Admin stuff for the checkout. Notably, point it to the SUSE fork,
 # that is where we will push the changes to.
 
-${HUB} config user.email "cf-ci-bot@suse.de"
+${HUB} config user.email "${GITHUB_USER}"
 ${HUB} config user.name  "${GITHUB_USER}"
 ${HUB} remote add -p FORK ${FORK}
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env sh
+set -e
+PATH=$PATH:$PWD/bin
+GOPATH=$PWD
+TOP=$PWD
+
+# This is the long-living fork of upstream we use to generate the PR
+# from.
+FORK=SUSE/cli-plugin-repo
+
+HUB_RELEASE=https://github.com/github/hub/releases/download/v2.3.0-pre10/hub-linux-amd64-2.3.0-pre10.tgz
+
+if [ -z "$UPSTREAM"  ]; then
+  echo "Don't know where to make the pull request, UPSTREAM is undefined"
+  exit 1
+fi
+
+# Configuration for `hub`.
+
+if [ -z "$GITHUB_USER"  ]; then
+  echo "GITHUB_USER environment variable not set"
+  # Example: "cf-ci-bot@suse.de"
+  exit 1
+fi
+if [ -z "$GITHUB_TOKEN"  ]; then
+  echo "GITHUB_TOKEN environment variable not set"
+  exit 1
+fi
+
+# # ## ### ##### ######## ############# #####################
+## SSH to github
+
+echo
+echo SSH setup ...
+
+# Need to set up access to the appropriate repos
+eval "$(ssh-agent)"
+trap "ssh-agent -k" EXIT
+
+grep --null-data '^GITHUB_KEY=' /proc/self/environ \
+    | tail -c +12 \
+    | tr '\0' '\n' \
+    | ssh-add /dev/stdin
+unset GITHUB_KEY
+
+# Pick up the SSH host key
+ssh -o StrictHostKeyChecking=no -l git github.com <&- 2>&1 \
+    | grep "successfully authenticated"
+
+# # ## ### ##### ######## ############# #####################
+## configuration
+
+echo
+echo Configuration ...
+
+# Inputs:
+# release/
+#	tag
+#	version
+#	body
+#	commit_sha
+#	<assets> (cf-*, L*, R*)
+# src-ci/
+
+TAG=$(cat release/tag)
+VER=$(cat release/version)
+NOW=$(date -u --iso-8601=s | sed -e 's/\+.*$/Z/')
+
+PR_BRANCH=cf-plugin-backup-${TAG}
+PR_TITLE="Release cf-plugin-backup ${TAG}"
+PR_DESC="Release cf-plugin-backup ${TAG} from https://github.com/SUSE/cf-plugin-backup/releases/${TAG}"
+
+echo 'TAG:    ' ${TAG}
+echo 'VERSION:' ${VER}
+echo 'NOW:    ' ${NOW}
+echo 'BRANCH: ' ${PR_BRANCH}
+echo 'gh_USER:' ${GITHUB_USER}
+# No, we will not show the token.
+
+# # ## ### ##### ######## ############# #####################
+## Assemble index information
+
+echo
+echo Assembling the yaml ...
+
+rm -f  index.yml
+cat >> index.yml <<EOF
+- authors:
+  - contact:  ${CONTACT}
+    homepage: ${HOMEURL}
+    name:     ${NAME}
+  binaries:
+EOF
+
+platform() {
+    local path="$1"
+    case $path in
+	*darwin-amd64*)  echo osx ;;
+	*linux-386*)     echo linux32 ;;
+	*linux-amd64*)   echo linux64 ;;
+	*windows-386*)   echo win32 ;;
+	*windows-amd64*) echo win64 ;;
+	*)               echo Unable to determine platform code
+	                 exit 1 ;;
+    esac
+}
+
+# Ignore the checksum files
+rm release/*.SHA256
+
+for asset in release/cf-plugin-backup-*
+do
+    echo
+    echo Processing $asset ...
+    HASH=$(sha1sum $asset | sed -e 's/ .*$//')
+    BASE=$(basename $asset)
+    PLAT=$(platform $asset)
+    echo '- SHA1:' $HASH
+    echo '- PLAT:' $PLAT
+
+    cat >> index.yml <<EOF
+  - checksum: ${HASH}
+    platform: ${PLAT}
+    url: https://github.com/SUSE/cf-plugin-backup/releases/download/${TAG}/${BASE}
+EOF
+done
+
+cat >> index.yml <<EOF
+  company:     ${COMPANY}
+  created:     ${NOW}
+  description: A plugin that enables backup and restore of the CCDB via the CF API 
+  homepage:    https://github.com/SUSE/cf-plugin-backup
+  name:        cf-plugin-backup
+  updated:     ${NOW}
+  version:     ${VER}
+EOF
+
+echo
+echo Assembled index:
+cat index.yml
+echo
+
+# # ## ### ##### ######## ############# #####################
+## Start on making the upstream PR
+
+echo
+echo Creating the pull request ...
+
+# Get the "hub" cli -- https://hub.github.com/hub.1.html
+curl -L ${HUB_RELEASE} | tar xvz --wildcards --strip-components=2 '*/bin/hub'
+HUB="${PWD}/hub"
+chmod +x ${HUB}
+
+# Clone the upstream github repo. The chosen directory name is
+# independent of the configured upstream name, during testing we may
+# operate on a repo with a different name.
+#
+# Note also that the chosen directory matches what the GO code expects
+# for its imports to work.
+
+echo ; echo = Clone
+
+mkdir -p                 src/code.cloudfoundry.org
+${HUB} clone ${UPSTREAM} src/code.cloudfoundry.org/cli-plugin-repo
+
+# Enter local checkout
+cd src/code.cloudfoundry.org/cli-plugin-repo
+
+# Admin stuff for the checkout. Notably, point it to the SUSE fork,
+# that is where we will push the changes to.
+
+${HUB} config user.email "cf-ci-bot@suse.de"
+${HUB} config user.name  "${GITHUB_USER}"
+${HUB} remote add -p FORK ${FORK}
+
+# Show the configured remotes
+git remote -v
+
+echo ; echo = Modify
+
+# Add our release to the index -- This are our changes
+cat ${TOP}/index.yml >> repo-index.yml
+go run sort/main.go   repo-index.yml
+
+# Create the branch, stage, commit and push the changes.
+# Note that the changes are pushed to the FORK, not origin
+
+echo ; echo = Branch
+${HUB} checkout -b ${PR_BRANCH}
+
+echo ; echo = Stage
+${HUB} -c core.fileMode=false add .
+
+echo ; echo = Commit
+${HUB} commit -m "Submitting ${PR_BRANCH}"
+
+echo ; echo = Push
+${HUB} push FORK ${PR_BRANCH}
+
+echo ; echo = PR
+# At last, open the Pull Request, head: current branch, base: master
+${HUB} pull-request \
+    -m "$(printf "${PR_TITLE}\n\n${PR_DESC}\n")" \
+    -b ${UPSTREAM}:master \
+    -h ${FORK}:${PR_BRANCH}
+
+echo ... Goodbye and godspeed
+exit

--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -6,6 +6,7 @@ image_resource:
     repository: golang
     tag: '1'
 inputs:
+  - name: hub-release
   - name: src-release
     path: release
   - name: src-ci

--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -1,0 +1,23 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: golang
+    tag: '1'
+inputs:
+  - name: src-release
+    path: release
+  - name: src-ci
+outputs:
+run:
+  path: src-ci/scripts/publish.sh
+params:
+  CONTACT: ~
+  NAME: ~
+  HOMEURL: ~
+  COMPANY: ~
+  UPSTREAM: ~
+  GITHUB_USER: ~
+  GITHUB_TOKEN: ~
+  GITHUB_KEY: ~


### PR DESCRIPTION
For the upload of plugin releases to the upstream `cloudfoundry/cli-plugin-repo`, in the form of a pull request from our fork at `SUSE/cli-plugin-repo`.

Ref: https://trello.com/c/X65gq5Ai/555-1-publish-new-backup-restore-cli-upstream-as-a-github-release

