### PR TITLE
dist: Disable CGO when building

### DIFF
--- a/tasks/dist.yaml
+++ b/tasks/dist.yaml
@@ -5,6 +5,8 @@ image_resource:
   source: 
     repository: golang
     tag: '1'
+params:
+  CGO_ENABLED: "0"
 inputs:
   - name: src
     path: src/github.com/SUSE/cf-plugin-backup


### PR DESCRIPTION
This should produce static binaries, suitable for e.g. alpine linux without pthreads support.